### PR TITLE
Fix the use of grow / unsafeGrow : the passed number is the number of…

### DIFF
--- a/Data/Vector/Mutable/Dynamic.hs
+++ b/Data/Vector/Mutable/Dynamic.hs
@@ -227,10 +227,10 @@ reserve (MVector v) i = do
     MVectorData s v' <- readMutVar v
     if (i < 0) then
         error "Data.Vector.Mutable.Dynamic: reserve: negative argument"
-    else if (s + i <= MV.length v') then
+    else if (i <= MV.length v') then
         return ()
     else do
-        v'' <- MV.unsafeGrow v' i
+        v'' <- MV.unsafeGrow v' (i-s)
         writeMutVar v (MVectorData s v'')
 {-# INLINABLE reserve #-}
 
@@ -239,10 +239,10 @@ reserve (MVector v) i = do
 unsafeReserve :: PrimMonad m => MVector (PrimState m) a -> Int -> m ()
 unsafeReserve (MVector v) i = do
     MVectorData s v' <- readMutVar v
-    if (s + i <= MV.length v') then
+    if (i <= MV.length v') then
         return ()
     else do
-        v'' <- MV.unsafeGrow v' i
+        v'' <- MV.unsafeGrow v' (i-s)
         writeMutVar v (MVectorData s v'')
 {-# INLINABLE unsafeReserve #-}
 
@@ -257,7 +257,7 @@ pushBack :: PrimMonad m => MVector (PrimState m) a -> a -> m ()
 pushBack (MVector v) a = do
     MVectorData s v' <- readMutVar v
     if (s == MV.length v') then do
-        v'' <- MV.unsafeGrow v' (s * 2 + 1)
+        v'' <- MV.unsafeGrow v' (s + 1) -- multiply the size of the vector by 2
         MV.unsafeWrite v'' s a
         writeMutVar v (MVectorData (s + 1) v'')
     else do
@@ -274,11 +274,7 @@ popBack (MVector v) = do
         error "Data.Vector.Mutable.Dynamic: popBack: empty vector"
     else do
         a <- MV.unsafeRead vec (s - 1)
-        if (s < quot (MV.length vec) 2) then do
-            vec' <- MV.unsafeGrow vec (s - 1)
-            writeMutVar v (MVectorData (s - 1) vec')
-        else
-            writeMutVar v (MVectorData (s - 1) vec)
+        writeMutVar v (MVectorData (s - 1) vec)
         return a
 {-# INLINABLE popBack #-}
 
@@ -287,11 +283,7 @@ unsafePopBack :: PrimMonad m => MVector (PrimState m) a -> m a
 unsafePopBack (MVector v) = do
     MVectorData s vec <- readMutVar v
     a <- MV.unsafeRead vec (s - 1)
-    if (s < quot (MV.length vec) 2) then do
-        vec' <- MV.unsafeGrow vec (s - 1)
-        writeMutVar v (MVectorData (s - 1) vec')
-    else
-        writeMutVar v (MVectorData (s - 1) vec)
+    writeMutVar v (MVectorData (s - 1) vec)
     return a
 {-# INLINABLE unsafePopBack #-}
 
@@ -336,7 +328,7 @@ extend (MVector a) (MVector b) = do
     MVectorData sa va <- readMutVar a
     MVectorData sb vb <- readMutVar b
     if (sa + sb > MV.length va) then do
-        va' <- MV.unsafeGrow va (sa + sb)
+        va' <- MV.unsafeGrow va sb
         MV.unsafeCopy (MV.unsafeSlice sa sb va') (MV.unsafeSlice 0 sb vb)
         writeMutVar a (MVectorData (sa + sb) va')
     else do
@@ -354,4 +346,3 @@ frozen v f = liftM f (freeze v)
 unsafeFrozen :: PrimMonad m => MVector (PrimState m) a -> (V.Vector a -> b) -> m b
 unsafeFrozen v f = liftM f (unsafeFreeze v)
 {-# INLINABLE unsafeFrozen #-}
-


### PR DESCRIPTION
… elements added to the vector

I saw that there was a problem when reading the code of popBack, which would sometimes allocate. Reading the other uses of grow / unsafeGrow I understood that there was a misunderstanding about the meaning of the number passed to grow / unsafeGrow : it is the number of elements that we want to add to the vector. I think the initial writer of the code understood that it would be the final size of the vector instead.

I hesitated writing unit tests due to a lack of time, but there is definitely a need for some unit tests I think.